### PR TITLE
fixed drm config to be nested within the source object

### DIFF
--- a/demo/components/playerExample/playerExampleConfig.brs
+++ b/demo/components/playerExample/playerExampleConfig.brs
@@ -9,7 +9,7 @@ function getExamplePlayerConfig()
     },
     source: {
       hls: "http://csm-e.cds1.yospace.com/access/d/400/u/0/1/130782300?f=0000130753172&format=vmap",
-      title: "Test video"
+      title: "Test video",
       assetType: "vod"
     }
   }
@@ -26,7 +26,7 @@ function getExamplePlayerConfigLive()
     },
     source: {
       hls: "http://csm-e.cds1.yospace.com/csm/extlive/yospace02,sampledroid.m3u8?yo.br=false&yo.ac=true",
-      title: "Test video"
+      title: "Test video",
       assetType: "live"
     }
   }
@@ -43,12 +43,12 @@ function getExamplePlayerConfigWidevineVod()
     },
     source: {
       hls: "http://example.com/vod.m3u8",
-      title: "Test video"
-      assetType: "vod"
-    },
-    drm: {
-      Widevine: {
-        LA_URL: "https://example.com/widevine/license"
+      title: "Test video",
+      assetType: "vod",
+      drm: {
+        widevine: {
+          LA_URL: "https://example.com/widevine/license"
+        }
       }
     }
   }
@@ -65,7 +65,7 @@ function getExamplePlayerConfigNonYospaceVod()
     },
     source: {
       hls: "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
-      title: "Test Non Yospace Live Stream"
+      title: "Test Non Yospace Live Stream",
       assetType: "none"
     }
   }
@@ -98,12 +98,12 @@ function getExamplePlayerConfigPlayreadyVod()
     },
     source: {
       hls: "http://example.com/vod.m3u8",
-      title: "Test video"
+      title: "Test video",
       assetType: "vod"
-    },
-    drm: {
-      Widevine: {
-        LA_URL: "https://example.com/playready/license"
+      drm: {
+        Widevine: {
+          LA_URL: "https://example.com/playready/license"
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem Description
The `playerExampleConfig.brs` file had some errors. This PR fixes those minor errors which lead to DRM encrypted content not playing back 
## Fix
Nested the `drm` object inside of the `source` object. I did not add a CHANGELOG entry as it was only a change to the demo app 

## Tests
Non Yospace URL:  https://turnercmaf.cdn.turner.com/qa/cmaf_advanced_fmp4_from_inter/prog_seg/bones_RADS1008071800025944_v12/cenc/3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c00000341/master_wv.m3u8
Yospace VOD URL: https://turnercmaf.cdn.turner.com/csm/qa/cmaf_advanced_fmp4_from_inter/prog_seg/bones_RADS1008071800025944_v12/cenc/3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c00000341/master_wv.m3u8?context=525947592
LA_URL: https://widevine.license.istreamplanet.com/widevine/api/license/a229afbf-e1d3-499e-8127-c33cd7231e58


## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
