### PR TITLE
Fix bugs around multiple source loads 

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
@@ -89,6 +89,7 @@ sub onSourceLoaded()
 end sub
 
 sub onSourceUnloaded()
+  reportPlayerStateChanged(m.top.BitmovinPlayerState.FINISHED)
   m.top.sourceUnloaded = m.bitmovinPlayer.sourceUnloaded
 end sub
 
@@ -132,7 +133,6 @@ sub pause(params)
 end sub
 
 sub unload(params)
-  reportPlayerStateChanged(m.top.BitmovinPlayerState.FINISHED)
   m.bitmovinPlayer.callFunc(m.top.BitmovinFunctions.UNLOAD, params)
 end sub
 


### PR DESCRIPTION
## Problem Description
1) The BitmovinYospaceIntegration would crash after you called `UNLOAD` / `LOAD` a couple times

2) We were not sending the `END` state to Yospace when a source was unloaded

## Fix
The root cause of the issue was due to the fact that we were calling adding new observers via `ObserveField` every time a new source was loaded. This was causing multiple listeners to fire the `LOAD` call and the Roku device would crash

We now only observe these fields once, no matter how many times you `LOAD` a new source 

## Tests
I built a new sample app in Tub that allows you to switch sources. You can test things there 

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
