### PR TITLE
add kidsContent boolean to setContentMetadata flag

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
@@ -427,8 +427,8 @@ sub onAdSkipped()
   m.top.adSkipped = m.yospaceTask.adSkipped
 end sub
 
-sub setContentMetaData(genre, id, length)
-  m.yospaceTask.callFunction = {id: m.BitmovinYospaceTaskEnums.Functions.SET_CONTENT_METADATA, arguments: [genre, id, length]}
+sub setContentMetaData(genre, kidsContent, id, length)
+  m.yospaceTask.callFunction = {id: m.BitmovinYospaceTaskEnums.Functions.SET_CONTENT_METADATA, arguments: [genre, kidsContent, id, length]}
 end sub
 
 sub updatePolicyHelper_seekStartPosition()

--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
@@ -228,7 +228,11 @@ sub callFunction(data)
   if data.id = m.BitmovinYospaceTaskEnums.Functions.SKIP_AD
     skipAd()
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.SET_CONTENT_METADATA
-    setContentMetaData(data.arguments.genre, data.arguments.id, data.arguments.length)
+    genre = data.arguments[0]
+    kidsContent = data.arguments[1]
+    id = data.arguments[2]
+    length = data.arguments[3]
+    setContentMetaData(genre, kidsContent, id, length)
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.SET_DEBUG_LEVEL
     setDebugLevel(data.arguments.debugLevel)
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.SET_ENABLE_RAF
@@ -242,9 +246,9 @@ sub setEnableRAF(enableRAF)
   task.SetUseRAF(enableRAF)
 end sub
 
-sub setContentMetadata(genre, id, length)
+sub setContentMetadata(genre, kidsContent, id, length)
   bridge = GetGlobalAA().taskman
-  bridge.SetContentGenre(genre)
+  bridge.SetContentGenre(genre, kidsContent)
   bridge.SetContentId(id)
   bridge.SetContentLength(length)
 end sub


### PR DESCRIPTION
## Problem Description
Yospace added functionality to pass kidsContent in the content metadata needed when RAF was enabled 

## Fix
 - Added kidsContent to the setContentMetadata method 
 - Fixed crash when accessing data.arguments 

## Tests
<!-- Reference unit tests and/or player tests or explain why testing is not possible/applicable. See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
