### PR TITLE
convert scheduleTime and GET_DURATION to relative time

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
@@ -71,7 +71,7 @@ end sub
 ' Called whenever the player enters an advert break
 sub onAdBreakStart(dummy as Dynamic)
   m.top.IsActiveAd = m.session.GetSession().GetCurrentBreak().IsActive()
-  m.top.activeAdBreak = mapAdBreak(m.session.GetSession().GetCurrentBreak())
+  m.top.activeAdBreak = mapAdBreak(m.session.GetSession().GetCurrentBreak(),m.top.Timeline)
   m.top.adBreakStart = true
 end sub
 
@@ -160,7 +160,7 @@ sub updateAdList()
     end for
     adList = []
     for each adElement in advertElements
-      adList.Push(mapAdBreak(adElement.GetAdverts())) ' GetAdverts() returns the adBreak contained in the advert timeline element
+      adList.Push(mapAdBreak(adElement.GetAdverts(),m.top.Timeline)) ' GetAdverts() returns the adBreak contained in the advert timeline element
     end for
     m.top.adList = adList
   else

--- a/YospaceIntegration/source/bitmovinYospacePlayer/utils/AdMapping.brs
+++ b/YospaceIntegration/source/bitmovinYospacePlayer/utils/AdMapping.brs
@@ -14,14 +14,43 @@ function mapAd(ad)
 end function
 
 ' Parameter name cannot be simply "adBreak" as it would interfere with an already existing "adBreak" from the yospaceSDK
-function mapAdBreak(myAdBreak)
+function mapAdBreak(myAdBreak, timeline)
   aBr = {
     id: myAdBreak._INSTANCEID,
-    scheduleTime: myAdBreak.GetStart(),
+    scheduleTime: toMagicTime(myAdBreak.GetStart(),timeline),
     ads: []
   }
   for each ad in myAdBreak.GetAdverts()
     aBr.ads.Push(mapAd(ad))
   end for
   return aBr
+end function
+
+function toMagicTime(playbackTime, timeline)
+  mTime = playbackTime
+
+  ' This additional offset contains the duration of ads already elapsed during an ad break
+  ' Multiple ads in an adbreak will have the same start offset, the offset of the ad break
+  offset = 0
+
+  if timeline = invalid
+    return mTime
+  end if
+
+  for each timelineElement in timeline.elements
+    if timelineElement.mode = "ADVERT"
+      if ((timelineElement.offset + offset) + timelineElement.size) < playbackTime
+        mTime -= timelineElement.size
+        offset += timelineElement.size
+      else if (playbackTime > (timelineElement.offset + offset)) and (playbackTime < ((timelineElement.offset + offset) + timelineElement.size))
+        mTime = (playbackTime - (timelineElement.offset + offset)) ' Subtract the time elapsed from content start to ad start
+        exit for ' No need to check the rest of the elements when we are currently in an ad
+      end if
+    else
+      ' Set offset to 0 since timeline entry is not an ad
+      offset = 0
+    end if
+  end for
+
+  return mTime
 end function


### PR DESCRIPTION
## Problem Description
Two time values were being exposed outside of the BitmovinPlayer as relative timestamps \
 - AdBreak scheduleTime 
 - GET_DURATION

## Fix
converted scheduleTime and duration to relative timestamps using the toMagicTime method 

## Tests
<!-- Reference unit tests and/or player tests or explain why testing is not possible/applicable. See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
