### PR TITLE
convert programmatic seeks to absolute times

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
@@ -67,7 +67,7 @@ sub onSeek()
 end sub
 
 sub onSeeked()
-  m.top.seeked = m.bitmovinPlayer.seeked
+  m.top.seeked = toMagicTime(m.bitmovinPlayer.seeked,m.yospaceTask.Timeline)
   checkIfSeekWasAllowed()
 end sub
 
@@ -145,6 +145,9 @@ sub seek(params)
   if m.policy.canSeek()
     seekDestination = m.policy.canSeekTo(params, getCurrentTime())
     if seekDestination <> params then m.policyHelper_originalSeekDestination = params
+    list = m.yospaceTask.adList
+    seekDestination = toAbsoluteTime(seekDestination, list) - 1
+    print "Seeking to destination: "; seekDestination
     m.bitmovinPlayer.callFunc(m.top.BitmovinFunctions.SEEK, seekDestination)
   end if
 end sub
@@ -415,6 +418,7 @@ sub checkIfSeekWasAllowed()
   allowedSeek = m.policy.canSeekTo(currentPlayerPosition, m.policyHelper_seekStartPosition)
   if (currentPlayerPosition <> allowedSeek) and (m.policyHelper_seekStartPosition > -1) and (m.policyHelper_originalSeekDestination = -1)
     m.policyHelper_originalSeekDestination = currentPlayerPosition
+    print "Seeking again because seek wasnt allowed: " + Str(m.policyHelper_originalSeekDestination) + " -> " + Str(allowedSeek)
     m.bitmovinPlayer.callFunc("seek", allowedSeek)
   end if
   m.policyHelper_seekStartPosition = -1

--- a/YospaceIntegration/source/bitmovinYospacePlayer/DefaultBitmovinYospacePlayerPolicy.brs
+++ b/YospaceIntegration/source/bitmovinYospacePlayer/DefaultBitmovinYospacePlayerPolicy.brs
@@ -19,7 +19,7 @@ function getDefaultBitmovinYospacePlayerPolicy()
         end for
         if skippedAdBreaks.Count() > 0
           adBreakToPlay = skippedAdBreaks[skippedAdBreaks.Count() - 1]
-          return adBreakToPlay.scheduleTime
+          seekTarget = adBreakToPlay.scheduleTime
         end if
         return seekTarget
       :end function,

--- a/YospaceIntegration/source/bitmovinYospacePlayer/utils/AdMapping.brs
+++ b/YospaceIntegration/source/bitmovinYospacePlayer/utils/AdMapping.brs
@@ -26,6 +26,31 @@ function mapAdBreak(myAdBreak, timeline)
   return aBr
 end function
 
+function toAbsoluteTime(relativeTime, list)
+   mTime = relativeTime
+
+  ' This additional offset contains the duration of ads already elapsed during an ad break
+  ' Multiple ads in an adbreak will have the same start offset, the offset of the ad break
+  offset = 0
+
+  if list = invalid
+    return mTime
+  end if
+
+  for each br in list
+    print br
+    print relativeTime
+    if br.scheduleTime < relativeTime
+      for each ad in br.ads
+        mTime += ad.duration
+      end for
+    end if
+  end for
+
+  return mTime
+
+end function
+
 function toMagicTime(playbackTime, timeline)
   mTime = playbackTime
 


### PR DESCRIPTION
## Problem Description
Seeking over anything but the first ad break resulted in the seek being adjust to an incorrect position. The reason for this was that the seek method was seeking to a relative time

## Fix
Convert all adjusted seeks to an absolute time so that we always end up in the expected seek position 

## Tests
 - Seek over the first ad break located at 209. Seek should be adjusted to 208 
 - Seek over the second ad break located at 596. Seek shoudl be adjusted to 595 

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
