### PR TITLE
Updated InitializationFailure field to always notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Improved documentation in README.md
 - Updated sample app to show how to listen to different kinds of events
+- Allow retryExcludingYospace to fire more than once per app session
 
 ### Fixed
 - A Crash when ads with no source are received.

--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.xml
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.xml
@@ -19,7 +19,7 @@
 	  <field id="IsAdvert" type="Boolean" />
 	  <field id="IsActiveAd" type="Boolean" />
 	  <field id="StreamType" type="String" />
-	  <field id="InitializationFailure" type="String" />
+	  <field id="InitializationFailure" type="String" alwaysNotify="true" />
 
 		<field id="adList" type="array" />
 		<field id="activeAdBreak" type="assocarray" />


### PR DESCRIPTION
## Problem Description
retryExcludingYospace was only able to fire once per session since the event field InitializationFailure was not set to always notify

## Fix
Fixed InitializationFailure field to always notify by adding alwaysNotify=true


## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
