### PR TITLE
Fix crash after end of VOD content playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Crash at end of VOD playback
+
+## [1.0.0]
 ### Added
 - Support for a custom Yospace ad policy as well as a default policy if none is set.
 - Fire `adBreakStart`, `adStart`, `adBreakFinished` and `adBreakFinished` respectively

--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
@@ -92,6 +92,10 @@ end sub
 
 ' Called whenever an individual advert completes
 sub onAdEnd(miid as String)
+  if miid = m.lastAd
+    YO_INFO("onAdEnd - miid {0} matches m.lastAd {1}; setting m.lastAd back to invalid", miid, m.lastAd)
+    m.lastAd = invalid
+  end if
   m.top.advertEnd = miid
   m.top.IsAdvert = false
   m.top.activeAd = invalid

--- a/YospaceIntegration/source/bitmovinYospacePlayer/DefaultBitmovinYospacePlayerPolicy.brs
+++ b/YospaceIntegration/source/bitmovinYospacePlayer/DefaultBitmovinYospacePlayerPolicy.brs
@@ -5,7 +5,9 @@ function initBitmovinYospacePlayerPolicy()
 
   this["markAdBreakWatched"] = function(br)
     print "Marking ad break as watched: "; br
-    m._watchedAdBreaks.Push(br.scheduleTime)
+    if br <> invalid
+      m._watchedAdBreaks.Push(br.scheduleTime)
+    end if
     print "Watched Ad Breaks: "; m._watchedAdBreaks
   end function
 


### PR DESCRIPTION
invalid type handling in markAdBreakWatched; m.lastAd updated back to invalid after onAdEnd fired for matching last ad

## Problem Description
VOD content was crashing at the end of the playback. This was due to a forced called to onAdBreakEnd with passing invalid as the parameter. 

## Fix
Fixed forced call to onAdBreakEnd. Added invalid type handling to markAdBreakWatched.

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed

