### PR TITLE
Conviva end session fixes

### DIFF
--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayer.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayer.brs
@@ -20,7 +20,7 @@ end sub
 
 sub onPlayerStateChanged()
   m.top.playerState = m.bitmovinPlayer.playerState
-  if m.top.playerState = m.top.BitmovinPlayerState.FINISHED or m.top.playerState = m.top.BitmovinPlayerState.ERROR
+  if m.top.playerState = m.top.BitmovinPlayerState.FINISHED or m.top.playerState = m.top.BitmovinPlayerState.ERROR or m.top.playerState = "stopped"
     m.yospaceTask.callFunction = { id: m.BitmovinYospaceTaskEnums.Functions.END_SESSION }
   end if
   reportPlayerStateChanged(m.top.playerState)

--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
@@ -192,6 +192,8 @@ sub callFunction(data)
     initializeConviva()
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.VIDEO_ERROR
     onVideoError()
+  else if data.id = m.BitmovinYospaceTaskEnums.Functions.END_SESSION
+    endSession()
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.MONITOR_VIDEO
     monitorVideo(data.arguments.contentMetaData)
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.MONITOR_YOSPACE_SDK


### PR DESCRIPTION
## Problem Description
With the updates for Conviva Ad Insights, sessions are not ended when the video is stopped or finished.  

There are two issues - 

1) Sessions are not ended when video is stopped because there's not a check for that player state change

2) There is not a "m.BitmovinYospaceTaskEnums.Functions.END_SESSION" callFunction handler in BitmovinYospaceConvivaPlayerTask

## Fix

Issue 1 was fixed by adding a check for player state changed of `stopped`.  Note, there's not a STOPPED enum in BitmovinPlayerState even though it's a valid state that the Bitmovin SDK emits so the string `stopped` had to be used. 

Issue 2 was fixed by adding a `m.BitmovinYospaceTaskEnums.Functions.END_SESSION` callFunction handler that calls `endSession()`