### PR TITLE
MECBM-607: Fix back on preroll

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
@@ -284,7 +284,7 @@ end function
 
 function checkLastAdFinishedWorkaround()
   video = m.top.bitmovinYospacePlayer.findNode("MainVideo")
-  if video.position >= (video.duration) then firePostRollFinishedEvents()
+  if Invalid <> video AND video.position >= (video.duration) then firePostRollFinishedEvents()
 end function
 
 function firePostRollFinishedEvents()


### PR DESCRIPTION
## Problem Description
When starting live content with Ads, if the video reproduction is being dismissed, an attempt to send post roll event is triggered but video is still not created.
App crashes.


## Fix
A simple validation of the video objet to allow checking if video position matches criteria on workaround method

## Tests
Play live with ads.
Prior end of the preroll ad, press back to dismiss video

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
