### PR TITLE
MECBM-610: Crash in ad break handlers if no current break

### DIFF
--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
@@ -212,14 +212,16 @@ sub callFunction(data)
 end sub
 
 ' The below methods should be removed once Conviva supports multiple listeners for YoSpace. Because for this Conviva version it overrides YoSpace callbacks
-sub onAdBreakStart(dummy as dynamic)
-  m.top.IsActiveAd = m.session.GetSession().GetCurrentBreak().IsActive()
-  m.top.activeAdBreak = mapAdBreak(m.session.GetSession().GetCurrentBreak(), m.top.Timeline)
-  m.top.adBreakStart = m.top.activeAdBreak
-  ' We call OnYoSpaceAdBreakStart() in order to report that an ad break has been started
-  ' Remove this once conviva allows multiple listeners for YoSpace callbacks
-  if m.isConvivaYoSpace then m.conviva.OnYoSpaceAdBreakStart(m.session.GetSession().GetCurrentBreak())
-  setContentPauseMonitoring()
+sub onAdBreakStart(dummy as Dynamic)
+  if (getCurrentAdBreak() <> invalid) then
+    m.top.IsActiveAd = getCurrentAdBreak().IsActive()
+    m.top.activeAdBreak = mapAdBreak(getCurrentAdBreak(), m.top.Timeline)
+    m.top.adBreakStart = m.top.activeAdBreak
+    ' We call OnYoSpaceAdBreakStart() in order to report that an ad break has been started
+    ' Remove this once conviva allows multiple listeners for YoSpace callbacks
+    if m.isConvivaYoSpace then m.conviva.OnYoSpaceAdBreakStart(getCurrentAdBreak())
+    setContentPauseMonitoring()
+  end if
 end sub
 
 sub onAdBreakEnd(dummy as dynamic)
@@ -228,7 +230,7 @@ sub onAdBreakEnd(dummy as dynamic)
   m.top.activeAdBreak = invalid
   ' We call OnYoSpaceAdBreakEnd() in order to report that an ad break has ended
   ' Remove this once conviva allows multiple listeners for YoSpace callbacks
-  if m.isConvivaYoSpace then m.conviva.OnYoSpaceAdBreakEnd(m.session.GetSession().GetCurrentBreak())
+  if m.isConvivaYoSpace then m.conviva.OnYoSpaceAdBreakEnd(getCurrentAdBreak())
   setContentResumeMonitoring()
 end sub
 

--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
@@ -70,10 +70,16 @@ end sub
 
 ' Called whenever the player enters an advert break
 sub onAdBreakStart(dummy as Dynamic)
-  m.top.IsActiveAd = m.session.GetSession().GetCurrentBreak().IsActive()
-  m.top.activeAdBreak = mapAdBreak(m.session.GetSession().GetCurrentBreak(),m.top.Timeline)
-  m.top.adBreakStart = m.top.activeAdBreak
+  if (getCurrentAdBreak() <> invalid) then
+    m.top.IsActiveAd = getCurrentAdBreak().IsActive()
+    m.top.activeAdBreak = mapAdBreak(getCurrentAdBreak(),m.top.Timeline)
+    m.top.adBreakStart = m.top.activeAdBreak
+  end if
 end sub
+
+function getCurrentAdBreak()
+  return m.session.GetSession().GetCurrentBreak()
+end function
 
 ' Called whenever an individual advert starts
 sub onAdStart(miid as String)


### PR DESCRIPTION
## Problem Description
We see occasional crashes in bitmovin-player-roku-integrations-yospace if `AdBreakStart` fires but `GetCurrentBreak()` in invalid.  

Example - 

```
Suspending threads...
Thread selected:  9*   ...nYospaceConvivaPlayerTask.brs(216)   m.top.IsActiveAd = m.session.GetSession().GetCurrentBreak().Current Function:
215:  sub onAdBreakStart(dummy as dynamic)
216:*   m.top.IsActiveAd = m.session.GetSession().GetCurrentBreak().IsActive()
217:    m.top.activeAdBreak = mapAdBreak(m.session.GetSession().GetCurrentBreak(), m.top.Timeline)
218:    m.top.adBreakStart = m.top.activeAdBreak
219:    ' We call OnYoSpaceAdBreakStart() in order to report that an ad break has been started
220:    ' Remove this once conviva allows multiple listeners for YoSpace callbacks
Source Digest(s): 
pkg: dev 1.0.1 f63c417967b1af4d9f3540bf26e55d3a March Madness Live'Dot' Operator attempted with invalid BrightScript Component or interface reference. (runtime error &hec) in turnerplayer:/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs(216)
Backtrace:
#6  Function onadbreakstart(dummy As Dynamic) As Void
   file/line: turnerplayer:/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs(216)
#5  Function $anon_d9a(data As Dynamic) As Dynamic
   file/line: turnerplayer:/source/yospace/Utils/rtGeneral.brs(191)
#4  Function ys_yss_breakstart(brk As Dynamic) As Void
   file/line: turnerplayer:/source/yospace/Public/YSSession.brs(838)
#3  Function ys_ysls_handlemetadata(data As Dynamic) As Void
   file/line: turnerplayer:/source/yospace/Public/YSLiveSession.brs(491)
#2  Function ys_yssm_reportplayerevent(evt As String, data As Dynamic) As Void
   file/line: turnerplayer:/source/yospace/Public/YSSessionManager.brs(538)
#1  Function reportplayerevent(data As Dynamic) As Void
   file/line: turnerplayer:/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs(234)
#0  Function monitorsdk() As Void
   file/line: turnerplayer:/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs(42)
Local Variables:
```

## Fix
The fix checks that `GetCurrentBreak()` is not invalid before trying to access its properties. The change had to be made in both BitmovinYospacePlayerTask.brs and BitmovinYospaceConvivaPlayerTask.brs since the latter overrides `onAdBreakStart` from the former. 