### PR TITLE
MECBM-611: Yospace errror when stop player is called and conviva is not configured

### DIFF
--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
@@ -107,10 +107,12 @@ sub createConvivaSession()
 end sub
 
 sub endSession()
-  debugLog("[ConvivaAnalytics] closing session")
-  m.conviva.endMonitoring(m.video)
-  m.top.cSession = false
-  m.contentMetadataBuilder.callFunc("reset")
+  if m.conviva <> invalid then
+    debugLog("[ConvivaAnalytics] closing session")
+    m.conviva.endMonitoring(m.video)
+    m.top.cSession = false
+    m.contentMetadataBuilder.callFunc("reset")
+  end if
 end sub
 
 sub reportPlaybackDeficiency(message, isFatal, closeSession = true)


### PR DESCRIPTION

## Problem Description
in the  pkg Roku_TurnerPlayer_2_0_1_beta2.pkg there is a crash when stopPlayer is called and conviva is not set, the issue is that end session is called and as conviva is invalid it crashes
## Fix
validates that conviva is configured to execute end session method

## Tests
<!-- Reference unit tests and/or player tests or explain why testing is not possible/applicable. See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
