### PR TITLE
MECBM-603: Conviva not properly tracking non-YS URLs

### DIFF
--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayer.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayer.brs
@@ -11,6 +11,7 @@ end sub
 sub onSourceLoaded()
   updateContentMetadata()
   m.top.sourceLoaded = m.bitmovinPlayer.sourceLoaded
+  m.yospaceTask.callFunction = { id: m.BitmovinYospaceTaskEnums.Functions.SOURCE_LOADED }
 end sub
 
 sub onTimeShift()

--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
@@ -96,6 +96,15 @@ sub onVideoError()
   end if
 end sub
 
+sub onSourceLoaded()
+  ' Conviva 3.0.9 starts content monitoring by watching for the video.control to go to "play". If video.control was already "play"
+  ' in createConvivaSession (e.g. for autoplay) then the Conviva session won't go into content monitoring unless explicitly
+  ' nudged to do so. Only resume monitoring if the control is currently "play" so non-autoplay video stay in the correct state.
+  if m.video <> invalid and m.video.control = "play"
+    setContentResumeMonitoring()
+  end if
+end sub
+
 sub createConvivaSession()
   m.video = m.top.player.findNode("MainVideo") ' Get latest video node
   buildContentMetadata()
@@ -192,6 +201,8 @@ sub callFunction(data)
     setEnableRAF(data.arguments.enableRAF)
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.INITIALIZE_CONVIVA
     initializeConviva()
+  else if data.id = m.BitmovinYospaceTaskEnums.Functions.SOURCE_LOADED
+    onSourceLoaded()
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.VIDEO_ERROR
     onVideoError()
   else if data.id = m.BitmovinYospaceTaskEnums.Functions.END_SESSION

--- a/YospaceIntegration/source/bitmovinYospacePlayer/enums/BitmovinYospaceTaskEnum.brs
+++ b/YospaceIntegration/source/bitmovinYospacePlayer/enums/BitmovinYospaceTaskEnum.brs
@@ -22,6 +22,7 @@ function getBitmovinYospaceTaskEnum()
       INITIALIZE_CONVIVA: "initializeConviva",
       MONITOR_VIDEO: "monitorVideo",
       MONITOR_YOSPACE_SDK: "monitorYoSpaceSDK",
+      SOURCE_LOADED: "sourceLoaded",
       VIDEO_ERROR: "videoError",
       UPDATE_CONTENT_METADATA: "updateContentMetadata",
       END_SESSION: "endSession",
@@ -29,7 +30,6 @@ function getBitmovinYospaceTaskEnum()
       REPORT_SEEK_STARTED: "reportSeekStarted",
       SEND_CUSTOM_APPLICATION_EVENT: "sendCustomApplicationEvent",
       SEND_CUSTOM_PLAYBACK_EVENT: "sendCustomPlaybackEvent"
-
     }
   }
 end function


### PR DESCRIPTION
## Problem Description

When auto-playing non-YoSpace content, the Conviva session never enters a playing state.  It stays in a not monitored ad state (see screenshot below).  

This can be reproduced by playing the `getExamplePlayerConfigNonYospaceVod()` in the demo. 

![Screen Shot 2021-02-05 at 12 50 32 AM](https://user-images.githubusercontent.com/1253193/109765338-b5dd8e80-7bc2-11eb-8d62-0e9763819008.png)

For whatever reason, the Conviva library starts all sessions in an ad state - 

![Screen Shot 2021-03-03 at 12 35 15 AM](https://user-images.githubusercontent.com/1253193/109765449-de658880-7bc2-11eb-9975-16555c22e235.png)

If then waits for the Video node's `control` property to become `play` which signifies a request to start playback.  When the `control` property becomes `play`, it exits out of the fake ad and starts tracking the Video node - 

![Screen Shot 2021-03-03 at 12 34 55 AM](https://user-images.githubusercontent.com/1253193/109765522-fa692a00-7bc2-11eb-9eda-734d04e75ffe.png)

The issue here is when playing non-YoSpace content with autoplay `true`, the Video node is already in `play` state before handing over to Bitmovin in `monitorVideo`.  Because it's already `play`, then Conviva never leaves the fake ad state. 

## Fix

To fix, I utilize `setContentResumeMonitoring` which does the same thing (end ad and attach streamer) as Conviva does when seeing the `play` state occur - 

![Screen Shot 2021-03-03 at 12 36 14 AM](https://user-images.githubusercontent.com/1253193/109766019-9eeb6c00-7bc3-11eb-97a3-62b87a69802f.png)

I'm doing this in onSourceLoaded and only if the Video node is already in `play` state.  By only doing if the Video node is in `play` state, we avoid inadvertently starting tracking of videos that are start paused. 

## Tests

Here's what the tracking of `getExamplePlayerConfigNonYospaceVod()` looks like after the change - 

![roku_autostart_non_ys](https://user-images.githubusercontent.com/1253193/109766261-f12c8d00-7bc3-11eb-8f2e-65474053a706.png)

I also tested these various use cases to ensure the data still looked correct - 

- Non-YoSpace autoplay
- Non-YoSpace start paused
- YoSpace autoplay with preroll
- YoSpace start paused with preroll
- YoSpace autoplay without preroll
- YoSpace start paused without preroll