### PR TITLE
MECBM-635 When live events  not going through YoSpace, fix the startO…

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayer.brs
@@ -383,6 +383,7 @@ sub onInitializationFailure()
 end sub
 
 sub verifyStartOffsetForLiveEvents()
+  if m.source = invalid or m.source.options = invalid or m.source.options.startOffset = invalid then return
   if m.source.LIVE and m.source.options.startOffset = 0 then
     m.source.options.startOffset = -1
     m.source.options.startOffsetTimelineReference = "end"


### PR DESCRIPTION
…ffset to start video at the end.

## Problem Description
https://jiraprod.turner.com/browse/MECBM-635
When not going through YoSpace, Live streams start at the beginning. This is not an issue when going through YoSpace because YoSpace adds a "#EXT-X-START:TIME-OFFSET" in the manifest that the underlying player respects. 

## Fix
<!-- Describe how you fixed it -->
When ssai profile it's not enable or when YS initialization fails and the assetType is live set the startoffset value  to -1 if this is cero.
## Tests
<!-- Reference unit tests and/or player tests or explain why testing is not possible/applicable. See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
