### PR TITLE
DRAFT : Create onPlaybackReady callback to starts playback before parsing ads (DO NOT MERGE)

### DIFF
--- a/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospacePlayer/BitmovinYospacePlayerTask.brs
@@ -58,13 +58,11 @@ sub onSessionReady(data = invalid as Dynamic)
     YO_ERROR("Initialization failed: {0}", data.status)
     m.top.InitializationFailure = data.status
   else
-    m.session.RegisterPlayer(m.player)
     m.top.StreamType = m.session.GetSession().GetStreamType()
     tl = m.session.GetSession().GetTimeline()
     if (tl <> invalid) then
       updateTimeline(tl)
     end if
-    m.top.PlaybackURL = m.session.GetMasterPlaylist()
   end if
 end sub
 
@@ -210,11 +208,21 @@ sub requestYospaceURL(data)
     m.session.CreateForLive(data.url, data.options, yo_Callback(onSessionReady, m))
     m.top.IsLive = true
   else if (data.type = m.BitmovinYospaceTaskEnums.StreamType.VOD)
-    m.session.CreateForVOD(data.url, data.options, yo_Callback(onSessionReady, m))
+    m.session.CreateForVOD(data.url, data.options, yo_Callback(onSessionReady, m), yo_Callback(onPlaybackReady, m))
     m.top.IsLive = false
   else if (data.type = m.BitmovinYospaceTaskEnums.StreamType.V_LIVE)
     m.session.CreateForNonLinear(data.url, data.options, yo_Callback(onSessionReady, m))
     m.top.IsLive = true
+  end if
+end sub
+
+sub onPlaybackReady(data = invalid as dynamic)
+  if (data.result <> YSSessionResult().INITIALISED) then
+    YO_ERROR("Initialization failed: {0}", data.status)
+    m.top.InitializationFailure = data.status
+  else
+    m.top.PlaybackURL = m.session.GetMasterPlaylist()
+    m.session.RegisterPlayer(m.player)
   end if
 end sub
 


### PR DESCRIPTION
## Problem Description
<!-- Describe the problem briefly -->

## Fix
<!-- Describe how you fixed it -->
This Pr is a POC to return playback url before parsing ads in yospace implementation for vod session, with this the playback starts early and it reduces the ttff. 

This pr depends on https://github.com/TurnerOpenPlatform/top-player-roku/pull/94 in top-player-roku

## Tests
<!-- Reference unit tests and/or player tests or explain why testing is not possible/applicable. See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
