### PR TITLE
fix: error on seek when m.conviva is not defined

### DIFF
--- a/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
+++ b/YospaceIntegration/components/bitmovinYospaceConvivaPlayer/BitmovinYospaceConvivaPlayerTask.brs
@@ -78,7 +78,9 @@ sub setContentResumeMonitoring()
 end sub
 
 sub reportSeekStarted()
-  m.conviva.reportSeekStarted(m.video, -1)
+  if isSessionActive()
+    m.conviva.reportSeekStarted(m.video, -1)
+  end if
 end sub
 
 sub onPlay()


### PR DESCRIPTION
## Problem Description
During seek attempt, debugger halts, and `m.conviva` does not exist.

## Fix
Used the same `isSessionActive()` check that other methods used.

## Tests


## Checklist (for PR submitters and reviewers)
- `CHANGELOG` entry
  - Correct version
  - Correct section and correct section order (Added/Changed/Deprecated/Removed/Fixed)
  - Without redundancy (e.g. no `Added foo` in `Added` section but rather just `Foo`)
  - No typos
  - Coherent argumentation why an entry is not needed
- Tests
  - Test(s) within the PR, and/or
  - Link(s) to existing test class(es) that cover the PR, and/or
  - Coherent argumentation why the PR cannot be covered by tests
